### PR TITLE
refactor: Reduce duplicate code for internal_execute

### DIFF
--- a/contract/src/internals/helpers.rs
+++ b/contract/src/internals/helpers.rs
@@ -10,40 +10,39 @@ pub(crate) fn hash_account_id(account_id: &String) -> CryptoHash {
 
 impl DropZone {
     /// Used to calculate the base allowance needed given attached GAS
-    pub(crate) fn calculate_base_allowance(&self, attached_gas: Gas) -> u128 {    
+    pub(crate) fn calculate_base_allowance(&self, attached_gas: Gas) -> u128 {
         // Get the number of CCCs you can make with the attached GAS
         let calls_with_gas = (attached_gas.0 / GAS_PER_CCC.0) as f32;
         // Get the constant used to pessimistically calculate the required allowance
         let pow_outcome = 1.03_f32.powf(calls_with_gas);
-        
+
         // Get the required GAS based on the calculated constant
-        let required_allowance = ((attached_gas.0 + RECEIPT_GAS_COST.0) as f32 * pow_outcome + RECEIPT_GAS_COST.0 as f32) as u128 * self.yocto_per_gas;
-        env::log_str(&format!("{} calls with {} attached GAS. Pow outcome: {}. Required Allowance: {}", calls_with_gas, attached_gas.0, pow_outcome, required_allowance));
+        let required_allowance = ((attached_gas.0 + RECEIPT_GAS_COST.0) as f32 * pow_outcome
+            + RECEIPT_GAS_COST.0 as f32) as u128
+            * self.yocto_per_gas;
+        env::log_str(&format!(
+            "{} calls with {} attached GAS. Pow outcome: {}. Required Allowance: {}",
+            calls_with_gas, attached_gas.0, pow_outcome, required_allowance
+        ));
 
         required_allowance
     }
 
     /// Add a drop ID to the set of drops a funder has
-    pub(crate) fn internal_add_drop_to_funder(
-        &mut self,
-        account_id: &AccountId,
-        drop_id: &DropId,
-    ) {
+    pub(crate) fn internal_add_drop_to_funder(&mut self, account_id: &AccountId, drop_id: &DropId) {
         //get the set of drops for the given account
         let mut drop_set = self.drop_ids_for_funder.get(account_id).unwrap_or_else(|| {
             //if the account doesn't have any drops, we create a new unordered set
-            UnorderedSet::new(
-                StorageKey::DropIdsForFunderInner {
-                    //we get a new unique prefix for the collection
-                    account_id_hash: hash_account_id(&account_id.to_string()),
-                }
-            )
+            UnorderedSet::new(StorageKey::DropIdsForFunderInner {
+                //we get a new unique prefix for the collection
+                account_id_hash: hash_account_id(&account_id.to_string()),
+            })
         });
 
         //we insert the drop ID into the set
         drop_set.insert(drop_id);
 
-        //we insert that set for the given account ID. 
+        //we insert that set for the given account ID.
         self.drop_ids_for_funder.insert(account_id, &drop_set);
     }
 
@@ -67,7 +66,7 @@ impl DropZone {
         if drop_set.is_empty() {
             self.drop_ids_for_funder.remove(account_id);
         } else {
-        //if the key set is not empty, we simply insert it back for the funder ID. 
+            //if the key set is not empty, we simply insert it back for the funder ID.
             self.drop_ids_for_funder.insert(account_id, &drop_set);
         }
     }
@@ -75,160 +74,98 @@ impl DropZone {
     /// Internal function for executing the callback code either straight up or using `.then` for a passed in promise
     pub(crate) fn internal_execute(
         &mut self,
-        drop_data: Drop, 
-        account_id: AccountId, 
+        drop_data: Drop,
+        account_id: AccountId,
         storage_freed: u128,
         token_id: Option<String>,
         storage_for_longest: Option<u128>,
-        promise: Option<Promise>
-    ) {        
-        // Determine what callback we should use depending on the drop type
-        match drop_data.drop_type {
-            DropType::FC(data) => {
-                // If we're dealing with a promise, execute the callback
+        promise: Option<Promise>,
+    ) {
+        macro_rules! resolve_promise_or_call {
+            ($($call:tt)*) => {
                 if let Some(promise) = promise {
                     promise.then(
                         // Call on_claim_fc with all unspent GAS + min gas for on claim. No attached deposit.
                         Self::ext(env::current_account_id())
                         .with_static_gas(MIN_GAS_FOR_ON_CLAIM)
-                        .on_claim_fc(
-                            // Account ID that claimed the linkdrop
-                            account_id, 
-                            // Account ID that funded the linkdrop
-                            drop_data.funder_id, 
-                            // Balance associated with the linkdrop
-                            drop_data.balance, 
-                            // How much storage was freed when the key was claimed
-                            storage_freed,
-                            // FC Data
-                            data,
-                            // Executing the function and treating it like a callback. 
-                            false
-                        )
+                        .$($call)*
                     );
                 } else {
                     // We're not dealing with a promise so we simply execute the function.
-                    self.on_claim_fc(
-                        // Account ID that claimed the linkdrop
-                        account_id, 
-                        // Account ID that funded the linkdrop
-                        drop_data.funder_id, 
-                        // Balance associated with the linkdrop
-                        drop_data.balance, 
-                        // How much storage was freed when the key was claimed
-                        storage_freed,
-                        // FC Data
-                        data,
-                        // Executing the function and treating it NOT like a callback. 
-                        true
-                    );
+                    self.$($call)*;
                 }
-            },
+            };
+        }
+        // Determine what callback we should use depending on the drop type
+        match drop_data.drop_type {
+            DropType::FC(data) => {
+                // If we're dealing with a promise, execute the callback
+                resolve_promise_or_call!(on_claim_fc(
+                    // Account ID that claimed the linkdrop
+                    account_id,
+                    // Account ID that funded the linkdrop
+                    drop_data.funder_id,
+                    // Balance associated with the linkdrop
+                    drop_data.balance,
+                    // How much storage was freed when the key was claimed
+                    storage_freed,
+                    // FC Data
+                    data,
+                    // Executing the function and treating it NOT like a callback.
+                    true,
+                ));
+            }
             DropType::NFT(data) => {
-                // If we're dealing with a promise, execute the callback
-                if let Some(promise) = promise {
-                    promise.then(
-                        // Call on_claim_nft with all unspent GAS + min gas for on claim. No attached deposit.
-                        Self::ext(env::current_account_id())
-                        .with_static_gas(MIN_GAS_FOR_ON_CLAIM)
-                        .on_claim_nft(
-                            // Account ID that claimed the linkdrop
-                            account_id, 
-                            // Account ID that funded the linkdrop
-                            drop_data.funder_id, 
-                            // Balance associated with the linkdrop
-                            drop_data.balance, 
-                            // How much storage was freed when the key was claimed
-                            storage_freed,
-                            // How much storage was prepaid to cover the longest token ID being inserted.
-                            storage_for_longest.expect("no storage for longest token Id found"),
-                            // Sender of the NFT
-                            data.nft_sender,
-                            // Contract where the NFT is stored
-                            data.nft_contract,
-                            // Token ID for the NFT
-                            token_id.expect("no token ID found"),
-                            // Executing the function and treating it like a callback. 
-                            false
-                        )
-                    );
-                } else {
-                    // We're not dealing with a promise so we simply execute the function.
-                    self.on_claim_nft(
-                        // Account ID that claimed the linkdrop
-                        account_id, 
-                        // Account ID that funded the linkdrop
-                        drop_data.funder_id, 
-                        // Balance associated with the linkdrop
-                        drop_data.balance, 
-                        // How much storage was freed when the key was claimed
-                        storage_freed,
-                        // How much storage was prepaid to cover the longest token ID being inserted.
-                        storage_for_longest.expect("no storage for longest token Id found"),
-                        // Sender of the NFT
-                        data.nft_sender,
-                        // Contract where the NFT is stored
-                        data.nft_contract,
-                        // Token ID for the NFT
-                        token_id.expect("no token ID found"),
-                        // Executing the function and treating it NOT like a callback. 
-                        true
-                    );
-                }
-            },
+                resolve_promise_or_call!(on_claim_nft(
+                    // Account ID that claimed the linkdrop
+                    account_id,
+                    // Account ID that funded the linkdrop
+                    drop_data.funder_id,
+                    // Balance associated with the linkdrop
+                    drop_data.balance,
+                    // How much storage was freed when the key was claimed
+                    storage_freed,
+                    // How much storage was prepaid to cover the longest token ID being inserted.
+                    storage_for_longest.expect("no storage for longest token Id found"),
+                    // Sender of the NFT
+                    data.nft_sender,
+                    // Contract where the NFT is stored
+                    data.nft_contract,
+                    // Token ID for the NFT
+                    token_id.expect("no token ID found"),
+                    // Executing the function and treating it like a callback.
+                    false,
+                ));
+            }
             DropType::FT(data) => {
-                // If we're dealing with a promise, execute the callback
-                if let Some(promise) = promise {
-                    promise.then(
-                        // Call on_claim_ft with all unspent GAS + min gas for on claim. No attached deposit.
-                        Self::ext(env::current_account_id())
-                        .with_static_gas(MIN_GAS_FOR_ON_CLAIM)
-                        .on_claim_ft(
-                            // Account ID that claimed the linkdrop
-                            account_id, 
-                            // Account ID that funded the linkdrop
-                            drop_data.funder_id, 
-                            // Balance associated with the linkdrop
-                            drop_data.balance, 
-                            // How much storage was freed when the key was claimed
-                            storage_freed,
-                            // FT Data to be used
-                            data,
-                            // Executing the function and treating it like a callback. 
-                            false
-                        )
-                    );
-                } else {
-                    // We're not dealing with a promise so we simply execute the function.
-                    self.on_claim_ft(
-                        // Account ID that claimed the linkdrop
-                        account_id, 
-                        // Account ID that funded the linkdrop
-                        drop_data.funder_id, 
-                        // Balance associated with the linkdrop
-                        drop_data.balance, 
-                        // How much storage was freed when the key was claimed
-                        storage_freed,
-                        // FT Data to be used
-                        data,
-                        // Executing the function and treating it NOT like a callback. 
-                        true
-                    );
-                }
-            },
+                resolve_promise_or_call!(on_claim_ft(
+                    // Account ID that claimed the linkdrop
+                    account_id,
+                    // Account ID that funded the linkdrop
+                    drop_data.funder_id,
+                    // Balance associated with the linkdrop
+                    drop_data.balance,
+                    // How much storage was freed when the key was claimed
+                    storage_freed,
+                    // FT Data to be used
+                    data,
+                    // Executing the function and treating it like a callback.
+                    false,
+                ));
+            }
             DropType::Simple => {
                 promise.unwrap().then(
                     // Call on_claim_simple with all unspent GAS + min gas for on claim. No attached deposit.
                     Self::ext(env::current_account_id())
-                    .with_static_gas(MIN_GAS_FOR_ON_CLAIM)
-                    .on_claim_simple(
-                        // Account ID that funded the linkdrop
-                        drop_data.funder_id, 
-                        // Balance associated with the linkdrop
-                        drop_data.balance, 
-                        // How much storage was freed when the key was claimed
-                        storage_freed,
-                    )
+                        .with_static_gas(MIN_GAS_FOR_ON_CLAIM)
+                        .on_claim_simple(
+                            // Account ID that funded the linkdrop
+                            drop_data.funder_id,
+                            // Balance associated with the linkdrop
+                            drop_data.balance,
+                            // How much storage was freed when the key was claimed
+                            storage_freed,
+                        ),
                 );
             }
         };


### PR DESCRIPTION
Was playing around to see how code could be reduced here by a q from @BenKurrek

I don't think there is a way to do this without a macro, since the two functions are different, but feel free to take or not take this PR

Sorry for the formatting changes, you guys don't use rustfmt and I was too lazy to manually format just the code I changed