### PR TITLE
Token Id Collectiono Change

### DIFF
--- a/contract/src/internals/helpers.rs
+++ b/contract/src/internals/helpers.rs
@@ -129,7 +129,10 @@ impl DropZone {
                     // Current number of claims left on the key before decrementing
                     cur_claims_for_key,
                     // Maximum number of claims
-                    drop_data.drop_config.max_claims_per_key,
+                    drop_data
+                        .drop_config
+                        .and_then(|c| c.max_claims_per_key)
+                        .unwrap_or(1),
                 ));
             }
             DropType::NFT(data) => {

--- a/contract/src/stage1/delete.rs
+++ b/contract/src/stage1/delete.rs
@@ -32,6 +32,13 @@ impl DropZone {
             "only drop funder can delete keys"
         );
 
+        // Get the max claims per key. Default to 1 if not specified in the drop config.
+        let max_claims_per_key = drop
+            .drop_config
+            .clone()
+            .and_then(|c| c.max_claims_per_key)
+            .unwrap_or(1);
+
         // Get optional costs
         let mut nft_optional_costs_per_key = 0;
         let mut ft_optional_costs_per_claim = 0;
@@ -94,7 +101,7 @@ impl DropZone {
 
                     // If there's one FC specified and more than 1 claim per key, that FC is to be used
                     // For all the claims. In this case, we need to tally all the deposits for each claim.
-                    if drop.drop_config.max_claims_per_key > 1 && num_fcs == 1 {
+                    if max_claims_per_key > 1 && num_fcs == 1 {
                         let deposit = data
                             .method_data
                             .iter()
@@ -111,8 +118,7 @@ impl DropZone {
                     } else {
                         // We need to loop through the remaining methods. This means we should skip and start at the
                         // MAX - keys left
-                        let starting_index =
-                            (drop.drop_config.max_claims_per_key - key_usage.num_uses) as usize;
+                        let starting_index = (max_claims_per_key - key_usage.num_uses) as usize;
                         for method in data.method_data.iter().skip(starting_index) {
                             total_num_none_fcs += method.is_none() as u64;
                             total_deposit_value += method.clone().map(|m| m.deposit.0).unwrap_or(0);
@@ -208,7 +214,7 @@ impl DropZone {
 
                     // If there's one FC specified and more than 1 claim per key, that FC is to be used
                     // For all the claims. In this case, we need to tally all the deposits for each claim.
-                    if drop.drop_config.max_claims_per_key > 1 && num_fcs == 1 {
+                    if max_claims_per_key > 1 && num_fcs == 1 {
                         let deposit = data
                             .method_data
                             .iter()
@@ -225,8 +231,7 @@ impl DropZone {
                     } else {
                         // We need to loop through the remaining methods. This means we should skip and start at the
                         // MAX - keys left
-                        let starting_index =
-                            (drop.drop_config.max_claims_per_key - key_usage.num_uses) as usize;
+                        let starting_index = (max_claims_per_key - key_usage.num_uses) as usize;
                         for method in data.method_data.iter().skip(starting_index) {
                             total_num_none_fcs += method.is_none() as u64;
                             total_deposit_value += method.clone().map(|m| m.deposit.0).unwrap_or(0);

--- a/contract/src/stage1/drops.rs
+++ b/contract/src/stage1/drops.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use near_sdk::{require, Balance};
+use near_sdk::{require, Balance, collections::Vector};
 
 pub type DropId = u128;
 
@@ -223,8 +223,8 @@ impl DropZone {
                 longest_token_id,
             } = data;
 
-            // Create the token ID set and insert the longest token ID
-            let token_ids = UnorderedSet::new(StorageKey::TokenIdsForDrop {
+            // Create the token ID vector and insert the longest token ID
+            let token_ids = Vector::new(StorageKey::TokenIdsForDrop {
                 //we get a new unique prefix for the collection
                 account_id_hash: hash_account_id(&format!("nft-{}{}", self.nonce, funder_id)),
             });
@@ -249,7 +249,7 @@ impl DropZone {
             let initial_nft_storage_one = env::storage_usage();
             // Now that the drop has been added, insert the longest token ID and measure storage
             if let DropType::NFT(data) = &mut drop.drop_type {
-                data.token_ids.insert(&longest_token_id);
+                data.token_ids.push(&longest_token_id);
             }
 
             // Add drop with the longest possible token ID and max storage
@@ -268,9 +268,9 @@ impl DropZone {
                 self.get_token_ids_for_drop(self.nonce, None, None)
             );
 
-            // Clear the token IDs so it's an empty set and put the storage in the drop's nft data
+            // Clear the token IDs so it's an empty vector and put the storage in the drop's nft data
             if let DropType::NFT(data) = &mut drop.drop_type {
-                data.token_ids.clear();
+                data.token_ids.pop();
                 data.storage_for_longest = storage_per_longest;
             }
 

--- a/contract/src/stage2/nft.rs
+++ b/contract/src/stage2/nft.rs
@@ -47,6 +47,13 @@ impl DropZone {
                 "token ID already registered"
             );
 
+            // Get the max claims per key. Default to 1 if not specified in the drop config.
+            let max_claims_per_key = drop
+                .drop_config
+                .clone()
+                .and_then(|c| c.max_claims_per_key)
+                .unwrap_or(1);
+
             // Re-insert the token IDs into the NFT Data struct
             nft_data.token_ids = token_ids;
 
@@ -55,9 +62,9 @@ impl DropZone {
             near_sdk::log!("drop.num_claims_registered {}", drop.num_claims_registered);
 
             // Ensure that the keys to register can't exceed the number of keys in the drop.
-            if drop.num_claims_registered > drop.pks.len() * drop.drop_config.max_claims_per_key {
+            if drop.num_claims_registered > drop.pks.len() * max_claims_per_key {
                 near_sdk::log!("Too many NFTs sent. Contract is keeping the rest.");
-                drop.num_claims_registered = drop.pks.len() * drop.drop_config.max_claims_per_key;
+                drop.num_claims_registered = drop.pks.len() * max_claims_per_key;
             }
 
             // Add the nft data back with the updated set

--- a/contract/src/stage3/claim.rs
+++ b/contract/src/stage3/claim.rs
@@ -590,8 +590,7 @@ impl DropZone {
         let mut should_continue = true;
         match &mut drop.drop_type {
             DropType::NFT(data) => {
-                token_id = data.token_ids.iter().next();
-                data.token_ids.remove(token_id.as_ref().unwrap());
+                token_id = data.token_ids.pop();
                 storage_for_longest = Some(data.storage_for_longest);
             }
             DropType::FC(data) => {

--- a/contract/src/stage3/claim.rs
+++ b/contract/src/stage3/claim.rs
@@ -29,7 +29,12 @@ impl DropZone {
         let storage_freed = storage_freed_option.unwrap();
 
         // Should we refund send back the $NEAR since an account isn't being created and just send the assets to the claiming account?
-        let account_to_transfer = if drop_data.drop_config.refund_if_claim.unwrap_or(false) == true
+        let account_to_transfer = if drop_data
+            .drop_config
+            .clone()
+            .and_then(|c| c.refund_if_claim)
+            .unwrap_or(false)
+            == true
         {
             drop_data.funder_id.clone()
         } else {
@@ -555,7 +560,8 @@ impl DropZone {
         let current_timestamp = env::block_timestamp();
         let desired_timestamp = drop
             .drop_config
-            .start_timestamp
+            .clone()
+            .and_then(|c| c.start_timestamp)
             .unwrap_or(current_timestamp);
 
         if current_timestamp < desired_timestamp {
@@ -592,7 +598,12 @@ impl DropZone {
                 // The starting index is the max claims per key - the number of uses left. If the method data is of size 1, use that instead
                 let cur_len = data.method_data.len() as u16;
                 let starting_index = if cur_len > 1 {
-                    (drop.drop_config.max_claims_per_key - key_usage.num_uses) as usize
+                    (drop
+                        .drop_config
+                        .clone()
+                        .and_then(|c| c.max_claims_per_key)
+                        .unwrap_or(1)
+                        - key_usage.num_uses) as usize
                 } else {
                     0 as usize
                 };
@@ -617,7 +628,7 @@ impl DropZone {
         );
 
         // Ensure the key is within the interval if specified
-        if let Some(interval) = drop.drop_config.usage_interval {
+        if let Some(interval) = drop.drop_config.clone().and_then(|c| c.usage_interval) {
             near_sdk::log!(
                 "Current timestamp {} last used: {} subs: {} interval: {}",
                 current_timestamp,

--- a/contract/src/views.rs
+++ b/contract/src/views.rs
@@ -25,7 +25,7 @@ pub struct JsonDrop {
     pub drop_type: JsonDropType,
 
     // The drop as a whole can have a config as well
-    pub drop_config: DropConfig,
+    pub drop_config: Option<DropConfig>,
 
     // Metadata for the drop
     pub drop_metadata: Option<DropMetadata>,
@@ -64,7 +64,7 @@ pub struct JsonKeyInfo {
     pub drop_type: JsonDropType,
 
     // The drop as a whole can have a config as well
-    pub drop_config: DropConfig,
+    pub drop_config: Option<DropConfig>,
 }
 
 #[near_bindgen]

--- a/contract/src/views.rs
+++ b/contract/src/views.rs
@@ -275,16 +275,6 @@ impl DropZone {
         }
     }
 
-    /// Returns if the current token ID lives in the NFT drop
-    pub fn drop_contains_token_id(&self, drop_id: DropId, token_id: String) -> bool {
-        let drop = self.drop_for_id.get(&drop_id).expect("no drop found");
-        if let DropType::NFT(nft_data) = drop.drop_type {
-            nft_data.token_ids.contains(&token_id)
-        } else {
-            false
-        }
-    }
-
     /// Paginate through token IDs in a drop
     pub fn get_token_ids_for_drop(
         &self,

--- a/deploy/ft/ft-add.js
+++ b/deploy/ft/ft-add.js
@@ -19,7 +19,7 @@ let config;
 let keyStore;
 
 let drop_config = {
-	max_claims_per_key: 2,
+	// max_claims_per_key: 2,
 
 	start_timestamp: 0,
 	// usage_interval: 6e11, // 10 minutes
@@ -94,7 +94,7 @@ async function start() {
 			{},
 			"300000000000000", 
 			parseNearAmount(
-				((parseFloat(LINKDROP_NEAR_AMOUNT) + KEY_FEE + OFFSET) * pubKeys.length * drop_config.max_claims_per_key).toString()
+				((parseFloat(LINKDROP_NEAR_AMOUNT) + KEY_FEE + OFFSET) * pubKeys.length * drop_config.max_claims_per_key || 1).toString()
 			)
 		);
 	} catch(e) {

--- a/deploy/ft/ft-create.js
+++ b/deploy/ft/ft-create.js
@@ -20,7 +20,7 @@ let config;
 let keyStore;
 
 let drop_config = {
-	max_claims_per_key: 2,
+	// max_claims_per_key: 2,
 
 	start_timestamp: 0,
 	// usage_interval: 6e11, // 10 minutes
@@ -112,7 +112,7 @@ async function start() {
 			{},
 			"300000000000000", 
 			parseNearAmount(
-				((parseFloat(LINKDROP_NEAR_AMOUNT) + KEY_FEE + OFFSET) * pubKeys.length * drop_config.max_claims_per_key + DROP_FEE).toString()
+				((parseFloat(LINKDROP_NEAR_AMOUNT) + KEY_FEE + OFFSET) * pubKeys.length * drop_config.max_claims_per_key || 1 + DROP_FEE).toString()
 			)
 		);
 	} catch(e) {

--- a/deploy/function-call/fc-add.js
+++ b/deploy/function-call/fc-add.js
@@ -18,7 +18,7 @@ let config;
 let keyStore;
 
 let drop_config = {
-	max_claims_per_key: 2,
+	// max_claims_per_key: 2,
 
 	start_timestamp: 0,
 	// usage_interval: 6e11, // 10 minutes
@@ -109,7 +109,7 @@ async function start() {
 			{},
 			"300000000000000", 
 			parseNearAmount(
-				((parseFloat(LINKDROP_NEAR_AMOUNT) + KEY_FEE + OFFSET + 1) * pubKeys.length * drop_config.max_claims_per_key).toString()
+				((parseFloat(LINKDROP_NEAR_AMOUNT) + KEY_FEE + OFFSET + 1) * pubKeys.length * drop_config.max_claims_per_key || 1).toString()
 			)
 		);
 	} catch(e) {

--- a/deploy/function-call/fc-create.js
+++ b/deploy/function-call/fc-create.js
@@ -19,7 +19,7 @@ let config;
 let keyStore;
 
 let drop_config = {
-	max_claims_per_key: 2,
+	// max_claims_per_key: 2,
 
 	start_timestamp: 0,
 	// usage_interval: 6e11, // 10 minutes
@@ -130,7 +130,7 @@ async function start() {
 			{},
 			"300000000000000", 
 			parseNearAmount(
-				((parseFloat(LINKDROP_NEAR_AMOUNT) + KEY_FEE + OFFSET + 1) * pubKeys.length * drop_config.max_claims_per_key + DROP_FEE).toString()
+				((parseFloat(LINKDROP_NEAR_AMOUNT) + KEY_FEE + OFFSET + 1) * pubKeys.length * drop_config.max_claims_per_key || 1 + DROP_FEE).toString()
 			)
 		);
 	} catch(e) {

--- a/deploy/nft/nft-add.js
+++ b/deploy/nft/nft-add.js
@@ -18,7 +18,7 @@ let config;
 let keyStore;
 
 let drop_config = {
-	max_claims_per_key: 2,
+	// max_claims_per_key: 2,
 
 	start_timestamp: 0,
 	// usage_interval: 6e11, // 10 minutes
@@ -110,7 +110,7 @@ async function start() {
 			{},
 			"300000000000000", 
 			parseNearAmount(
-				((parseFloat(LINKDROP_NEAR_AMOUNT) + KEY_FEE + OFFSET) * pubKeys.length * drop_config.max_claims_per_key).toString()
+				((parseFloat(LINKDROP_NEAR_AMOUNT) + KEY_FEE + OFFSET) * pubKeys.length * drop_config.max_claims_per_key || 1).toString()
 			)
 		);
 	} catch(e) {

--- a/deploy/nft/nft-create.js
+++ b/deploy/nft/nft-create.js
@@ -19,7 +19,7 @@ let config;
 let keyStore;
 
 let drop_config = {
-	max_claims_per_key: 2,
+	// max_claims_per_key: 2,
 
 	start_timestamp: 0,
 	// usage_interval: 6e11, // 10 minutes
@@ -131,7 +131,7 @@ async function start() {
 			{},
 			"300000000000000", 
 			parseNearAmount(
-				((parseFloat(LINKDROP_NEAR_AMOUNT) + KEY_FEE + OFFSET) * pubKeys.length * drop_config.max_claims_per_key + DROP_FEE).toString()
+				((parseFloat(LINKDROP_NEAR_AMOUNT) + KEY_FEE + OFFSET) * pubKeys.length * drop_config.max_claims_per_key || 1 + DROP_FEE).toString()
 			)
 		);
 	} catch(e) {

--- a/deploy/simple/simple-add.js
+++ b/deploy/simple/simple-add.js
@@ -18,7 +18,7 @@ let config;
 let keyStore;
 
 let drop_config = {
-	max_claims_per_key: 2,
+	// max_claims_per_key: 2,
 
 	start_timestamp: 0,
 	// usage_interval: 6e11, // 10 minutes
@@ -93,7 +93,7 @@ async function start() {
 			{},
 			"300000000000000", 
 			parseNearAmount(
-				((parseFloat(LINKDROP_NEAR_AMOUNT) + KEY_FEE + OFFSET) * pubKeys.length * drop_config.max_claims_per_key).toString()
+				((parseFloat(LINKDROP_NEAR_AMOUNT) + KEY_FEE + OFFSET) * pubKeys.length * drop_config.max_claims_per_key || 1).toString()
 			)
 		);
 	} catch(e) {

--- a/deploy/simple/simple-create.js
+++ b/deploy/simple/simple-create.js
@@ -19,7 +19,7 @@ let config;
 let keyStore;
 
 let drop_config = {
-	max_claims_per_key: 2,
+	// max_claims_per_key: 2,
 
 	start_timestamp: 0,
 	usage_interval: 1e10, // 10 seconds
@@ -111,7 +111,7 @@ async function start() {
 			{},
 			"300000000000000", 
 			parseNearAmount(
-				((parseFloat(LINKDROP_NEAR_AMOUNT) + KEY_FEE + OFFSET) * pubKeys.length * drop_config.max_claims_per_key + DROP_FEE).toString()
+				((parseFloat(LINKDROP_NEAR_AMOUNT) + KEY_FEE + OFFSET) * pubKeys.length * drop_config.max_claims_per_key || 1 + DROP_FEE).toString()
 			)
 		);
 	} catch(e) {


### PR DESCRIPTION
Changed token IDs in NFTData to be stored in a vector rather than an unordered set.
Changed refund mechanics to remove token IDs from the vector BEFORE the refund goes through. If the refund is successful, nothing happens. If the refund fails, the token IDs are popped back onto the vector.