### PR TITLE
Unnecessary Computation in Add Keys

### DIFF
--- a/__tests__/stage1/test-simple.ava.ts
+++ b/__tests__/stage1/test-simple.ava.ts
@@ -279,3 +279,55 @@ test('Refunding Critically Registered Simple Drop', async t => {
     console.log('aliBal: ', aliBal);
     t.is(aliBal, NEAR.parse("15").toString());
 });
+
+test('Not enough attached deposit during add_keys', async t => {
+    const { keypom, ali, bob } = t.context.accounts;
+    
+    await ali.updateAccount({
+        amount: NEAR.parse('10000 N').toString()
+    })
+
+    let {keys, publicKeys} = await generateKeyPairs(5);
+        
+    await ali.call(keypom, 'create_drop', {public_keys: [publicKeys[0]], deposit_per_use: NEAR.parse('100').toString()}, {gas: WALLET_GAS, attachedDeposit: NEAR.parse("101").toString()});
+
+
+    await ali.call(keypom, 'withdraw_from_balance', {});
+
+    let keypomBalanceBefore = await keypom.balance();
+    console.log('keypom available INITIAL: ', keypomBalanceBefore.available.toString())
+    console.log('keypom staked INITIAL: ', keypomBalanceBefore.staked.toString())
+    console.log('keypom stateStaked INITIAL: ', keypomBalanceBefore.stateStaked.toString())
+    console.log('keypom total INITIAL: ', keypomBalanceBefore.total.toString())
+
+    let aliBalBefore = await ali.balance();
+    console.log('aliBalBefore available: ', aliBalBefore.available.toString())
+    console.log('aliBalBefore staked: ', aliBalBefore.staked.toString())
+    console.log('aliBalBefore stateStaked: ', aliBalBefore.stateStaked.toString())
+    console.log('aliBalBefore total: ', aliBalBefore.total.toString())
+
+    // Should fail due to not enough attached deposit
+    try {
+        await ali.call(keypom, 'add_keys', {drop_id: "0", public_keys: [publicKeys[1]]}, {gas: WALLET_GAS, attachedDeposit: NEAR.parse("50").toString()});
+    } catch(e) {}
+
+    let keypomBalanceAfter = await keypom.balance();
+    console.log('keypomBalanceAfter available: ', keypomBalanceAfter.available.toString())
+    console.log('keypomBalanceAfter staked: ', keypomBalanceAfter.staked.toString())
+    console.log('keypomBalanceAfter stateStaked: ', keypomBalanceAfter.stateStaked.toString())
+    console.log('keypomBalanceAfter total: ', keypomBalanceAfter.total.toString())
+
+    let aliBalAfter = await ali.balance();
+    console.log('aliBalAfter available: ', aliBalAfter.available.toString())
+    console.log('aliBalAfter staked: ', aliBalAfter.staked.toString())
+    console.log('aliBalAfter stateStaked: ', aliBalAfter.stateStaked.toString())
+    console.log('aliBalAfter total: ', aliBalAfter.total.toString())
+
+    let aliContractBal = await keypom.view('get_user_balance', {account_id: ali});
+    console.log('aliContractBal: ', aliContractBal)
+
+    t.assert(aliContractBal === "0");
+    t.assert(NEAR.from(aliBalBefore.available).sub(NEAR.from(aliBalAfter.available)).lte(NEAR.parse("0.01")));
+    t.assert(NEAR.from(keypomBalanceBefore.available).sub(NEAR.from(keypomBalanceAfter.available)).lte(NEAR.parse("0.01")));
+    t.is(keypomBalanceBefore.stateStaked.toString(),keypomBalanceAfter.stateStaked.toString());
+});

--- a/contract/src/stage1/drops.rs
+++ b/contract/src/stage1/drops.rs
@@ -875,31 +875,6 @@ impl Keypom {
         /*
             Ensure the attached attached_deposit can cover:
         */
-        if current_user_balance < required_deposit {
-            near_sdk::log!(
-                "Not enough user balance. Found {} expected: {}",
-                yocto_to_near(current_user_balance),
-                yocto_to_near(required_deposit)
-            );
-            current_user_balance -= near_attached;
-
-            // If they have a balance, insert it back into the map otherwise remove it
-            if current_user_balance > 0 {
-                self.user_balances.insert(&funder, &current_user_balance);
-            } else {
-                self.user_balances.remove(&funder);
-            }
-
-            // Refund the predecessor for their attached deposit if it's greater than 0
-            if near_attached > 0 {
-                Promise::new(env::predecessor_account_id()).transfer(near_attached);
-            }
-
-            // Remove the drop
-            self.internal_remove_drop(&drop_id.0, keys_to_iter);
-            // Return early
-            return None;
-        }
         require!(
             current_user_balance >= required_deposit,
             "Not enough attached_deposit"


### PR DESCRIPTION
We can just use require!() instead of soft returning and doing unnecessary computations.