### PR TITLE
Panics From Rust SDK Data Types

### DIFF
--- a/__tests__/config-tests/config-tests.ava.ts
+++ b/__tests__/config-tests/config-tests.ava.ts
@@ -103,14 +103,6 @@ test('Testing Delete On Empty Config', async t => {
     for(var i = 0; i < 2; i++) {
         //set access key to be used for following transactions
         await keypom.setKey(keys[i]);
-        //give full access to the key above; used to circumvent allowance bug in sandbox (should be fixed now so this can be deleted)
-        await keypom.updateAccessKey(
-            publicKeys[i],  // public key
-            {
-                nonce: 0,
-                permission: 'FullAccess'
-            }
-        )
         //claim wallet gas to ali's account. wallet gas is 1NEAR, looping through twice should give him 2NEAR
         await keypom.call(keypom, 'claim', {account_id: ali.accountId}, {gas: WALLET_GAS});
         //after this, the access key should be deleted as it has been used. This means adding the new one is fresh. 
@@ -162,7 +154,7 @@ test('Testing Start Timestamp', async t => {
 
     //set access key to be used for following transactions
     await keypom.setKey(keys[0]);
-    //give full access to the key above; used to circumvent allowance bug in sandbox (should be fixed now so this can be deleted)
+    //give full access to the key above since failing a transaction would lead to not enough allowance on a regular function call access key
     await keypom.updateAccessKey(
         publicKeys[0],  // public key
         {
@@ -227,14 +219,6 @@ test('Testing Throttle Timestamp', async t => {
 
     //set first key as the key to be used to sign txns
     await keypom.setKey(keys[0]);
-    //give this key a full access key
-    await keypom.updateAccessKey(
-        publicKeys[0],  // public key
-        {
-            nonce: 0,
-            permission: 'FullAccess'
-        }
-    )
     // TWO CONSECUTIVE CLAIMS SHOULD FAIL BECAUSE THE THROTTLE TIMESTAMP HASN'T BEEN REACHED
     await keypom.call(keypom, 'claim', {account_id: ali.accountId}, {gas: WALLET_GAS});
     await keypom.call(keypom, 'claim', {account_id: ali.accountId}, {gas: WALLET_GAS});
@@ -296,15 +280,6 @@ test('Testing On Claim Refund Deposit', async t => {
     
     //set key to be used to sign txns
     await keypom.setKey(keys[0]);
-    //give that key full access
-    await keypom.updateAccessKey(
-        publicKeys[0],  // public key
-        {
-            nonce: 0,
-            permission: 'FullAccess'
-        }
-        )
-    
     // Set ali's balance to 0 so we can check if the claim works properly
     await ali.updateAccount({
         amount: "0"
@@ -375,13 +350,6 @@ test('Testing Custom Drop Root', async t => {
     
     //non-config key set as the key being used
     await keypom.setKey(keysNoConfig[0]);
-    await keypom.updateAccessKey(
-        publicKeysNoConfig[0],  // public key
-        {
-            nonce: 0,
-            permission: 'FullAccess'
-        }
-    )
     // SHOULD NOT WORK as you are using a nonConfig key & drop to deposit to a new account with a custom root
     await keypom.call(keypom, 'create_account_and_claim', {new_account_id: `foo.${customRoot.accountId}`, new_public_key : pks2[0]}, {gas: WALLET_GAS});
     let doesExist = await newAccountCorrect.exists();
@@ -389,14 +357,7 @@ test('Testing Custom Drop Root', async t => {
     t.is(doesExist, false);
 
     //set config key as the key being used
-        await keypom.setKey(keysConfig[0]);
-    await keypom.updateAccessKey(
-        publicKeysConfig[0],  // public key
-        {
-            nonce: 0,
-            permission: 'FullAccess'
-        }
-    )
+    await keypom.setKey(keysConfig[0]);
     //drain owner balance 
     await owner.call(keypom, 'withdraw_from_balance', {});
     let ownerBal: string = await keypom.view('get_user_balance', {account_id: owner.accountId});
@@ -421,13 +382,6 @@ test('Testing Custom Drop Root', async t => {
 
     //set second config key to be used as first one would have been deleted
     await keypom.setKey(keysConfig[1]);
-    await keypom.updateAccessKey(
-        publicKeysConfig[1],  // public key
-        {
-            nonce: 0,
-            permission: 'FullAccess'
-        }
-    )
 
     //this second custom root create account and claim should go through as the config key is being used
     await keypom.call(keypom, 'create_account_and_claim', {new_account_id: `foo.${customRoot.accountId}`, new_public_key : pks2[0]}, {gas: WALLET_GAS});
@@ -479,13 +433,6 @@ test('Testing Auto Withdraw', async t => {
     // Loop through 2 times and claim the keys [0, 1]
     for (let i = 0; i < 2; i++) {
         await keypom.setKey(keys[i]);
-        await keypom.updateAccessKey(
-            publicKeys[i],  // public key
-            {
-                nonce: 0,
-                permission: 'FullAccess'
-            }
-        )
         //1st run --> 1/1key uses used on keys[0], key should be deleted but drop still exists
         //2nd run --> 1/1 key uses used on keys[1], key AND drop should be deleted as per config2
         await keypom.call(keypom, 'claim', {account_id: ali.accountId}, {gas: WALLET_GAS});
@@ -525,13 +472,6 @@ test('Testing Auto Withdraw', async t => {
 
     //set keys[2] as the key being used
     await keypom.setKey(keys[2]);
-    await keypom.updateAccessKey(
-        publicKeys[2],  // public key
-        {
-            nonce: 0,
-            permission: 'FullAccess'
-        }
-    )
 
     //claim to Ali's account
     //once they key is used (and is the only and last key on this drop) and delted, the remaining balance in owner's Keypom wallet is refunded back to their NEAR wallet. 
@@ -751,13 +691,6 @@ test('Testing End Timestamp', async t => {
 
     //set keys[0] to be used
     await keypom.setKey(keys[0]);
-    await keypom.updateAccessKey(
-        publicKeys[0],  // public key
-        {
-            nonce: 0,
-            permission: 'FullAccess'
-        }
-    )
     // THIS SHOULD PASS as its before the end timestamp
     await keypom.call(keypom, 'claim', {account_id: ali.accountId}, {gas: WALLET_GAS});
 
@@ -820,9 +753,6 @@ test('Testing End Timestamp Key Drainage', async t => {
 
     //use key[0]
     await keypom.setKey(keys[0]);
-    await keypom.updateAccessKey(
-        publicKeys[0],  // public key
-    )
 
     // Loop 50 times and try to claim
     for (let i = 0; i < 50; i++) {
@@ -877,13 +807,6 @@ test('Testing Claim Interval', async t => {
 
     //use keys[0]
     await keypom.setKey(keys[0]);
-    await keypom.updateAccessKey(
-        publicKeys[0],  // public key
-        {
-            nonce: 0,
-            permission: 'FullAccess'
-        }
-    )
     // THIS SHOULD FAIL BECAUSE THE INTERVAL HASN'T BEEN REACHED
     await keypom.call(keypom, 'claim', {account_id: ali.accountId}, {gas: WALLET_GAS});
 
@@ -946,13 +869,6 @@ test('Testing All Time Based Configs Together', async t => {
 
     //set keys[0] to be claimed
     await keypom.setKey(keys[0]);
-    await keypom.updateAccessKey(
-        publicKeys[0],  // public key
-        {
-            nonce: 0,
-            permission: 'FullAccess'
-        }
-    )
     // THIS SHOULD FAIL BECAUSE THE INTERVAL HASN'T BEEN REACHED
     await keypom.call(keypom, 'claim', {account_id: ali.accountId}, {gas: WALLET_GAS});
 

--- a/__tests__/ft-drops/ft-drops.ava.ts
+++ b/__tests__/ft-drops/ft-drops.ava.ts
@@ -137,13 +137,6 @@ test('Claim Multi FT Drop And Ensure Keypom Balance Increases', async t => {
 
     for(let i = 0; i < 5; i++) {
         await keypom.setKey(keys[i]);
-        await keypom.updateAccessKey(
-            keys[i],  // public key
-            {
-                nonce: 0,
-                permission: 'FullAccess'
-            }
-        )
 
         await keypom.call(keypom, 'create_account_and_claim', {new_account_id: `${i}.test.near`, new_public_key : publicKeys[5]}, {gas: WALLET_GAS});
         await keypom.call(keypom, 'claim', {account_id: `${i}.test.near`}, {gas: WALLET_GAS});
@@ -233,13 +226,7 @@ test('OverRegister FTs and add multi use key later', async t => {
     await owner.call(keypom, 'add_to_balance', {}, {attachedDeposit: NEAR.parse("20").toString()});
     await owner.call(keypom, 'add_keys', {drop_id: '0', public_keys: [publicKeys[0]]}, {gas: LARGE_GAS});
     await keypom.setKey(keys[0]);
-    await keypom.updateAccessKey(
-        keys[0],  // public key
-        {
-            nonce: 0,
-            permission: 'FullAccess'
-        }
-    )
+
     for(let i = 0; i < 5; i++) {
         await keypom.call(keypom, 'create_account_and_claim', {new_account_id: `${i}.test.near`, new_public_key : publicKeys[1]}, {gas: WALLET_GAS});
         await keypom.call(keypom, 'claim', {account_id: `${i}.test.near`}, {gas: WALLET_GAS});
@@ -390,13 +377,7 @@ test('Refunding Assets and Deleting Multi Use Keys and Drops', async t => {
     await sendFTs(minter, (oneGtNear * BigInt(10)).toString(), keypom, ftContract, "0");
 
     await keypom.setKey(keys[0]);
-    await keypom.updateAccessKey(
-        keys[0],  // public key
-        {
-            nonce: 0,
-            permission: 'FullAccess'
-        }
-    )
+
     // Use the key 5 out of 10 times
     for(let i = 0; i < 5; i++) {
         await keypom.call(keypom, 'create_account_and_claim', {new_account_id: `${i}.test.near`, new_public_key : publicKeys[1]}, {gas: WALLET_GAS});

--- a/__tests__/nft-drops/nft-drops.ava.ts
+++ b/__tests__/nft-drops/nft-drops.ava.ts
@@ -111,13 +111,6 @@ test('Claim Multi NFT Drop And Ensure Keypom Balance Increases', async t => {
 
     for(let i = 0; i < 5; i++) {
         await keypom.setKey(keys[i]);
-        await keypom.updateAccessKey(
-            keys[i],  // public key
-            {
-                nonce: 0,
-                permission: 'FullAccess'
-            }
-        )
 
         await keypom.call(keypom, 'create_account_and_claim', {new_account_id: `${i}.test.near`, new_public_key : publicKeys[5]}, {gas: WALLET_GAS});
         await keypom.call(keypom, 'claim', {account_id: `${i}.test.near`}, {gas: WALLET_GAS});
@@ -209,13 +202,7 @@ test('OverRegister NFTs and add multi use key later', async t => {
     await owner.call(keypom, 'add_to_balance', {}, {attachedDeposit: NEAR.parse("20").toString()});
     await owner.call(keypom, 'add_keys', {drop_id: '0', public_keys: [publicKeys[0]]}, {gas: LARGE_GAS});
     await keypom.setKey(keys[0]);
-    await keypom.updateAccessKey(
-        keys[0],  // public key
-        {
-            nonce: 0,
-            permission: 'FullAccess'
-        }
-    )
+
     for(let i = 0; i < 5; i++) {
         await keypom.call(keypom, 'create_account_and_claim', {new_account_id: `${i}.test.near`, new_public_key : publicKeys[1]}, {gas: WALLET_GAS});
         await keypom.call(keypom, 'claim', {account_id: `${i}.test.near`}, {gas: WALLET_GAS});
@@ -414,13 +401,7 @@ test('Refunding Assets and Deleting Multi Use Keys and Drops', async t => {
     await sendNFTs(minter, ["1:1", "1:2", "1:3", "1:4", "1:5", "1:6", "1:7", "1:8", "1:9", "1:10"], keypom, nftSeries, "0");
 
     await keypom.setKey(keys[0]);
-    await keypom.updateAccessKey(
-        keys[0],  // public key
-        {
-            nonce: 0,
-            permission: 'FullAccess'
-        }
-    )
+    
     // Use the key 5 out of 10 times
     for(let i = 0; i < 5; i++) {
         await keypom.call(keypom, 'create_account_and_claim', {new_account_id: `${i}.test.near`, new_public_key : publicKeys[1]}, {gas: WALLET_GAS});

--- a/__tests__/passwords/password-tests.ava.ts
+++ b/__tests__/passwords/password-tests.ava.ts
@@ -86,13 +86,6 @@ test('Multi-use keys with local passwords', async t => {
     },{gas: LARGE_GAS});
 
     await keypom.setKey(keys[0]);
-    await keypom.updateAccessKey(
-        publicKeys[0],  // public key
-        {
-            nonce: 0,
-            permission: 'FullAccess'
-        }
-    )
 
     // Set ali's balance to 0 so we can check if the claim works properly
     await ali.updateAccount({
@@ -165,13 +158,7 @@ test('2 keys have local (first with all use pw second with only 1 use pw), 1 has
     *   LOCAL KEY #1
     */
     await keypom.setKey(keys[0]);
-    await keypom.updateAccessKey(
-        publicKeys[0],  // public key
-        {
-            nonce: 0,
-            permission: 'FullAccess'
-        }
-    )
+
     // Set ali's balance to 0 so we can check if the claim works properly
     await ali.updateAccount({
         amount: "0"
@@ -205,13 +192,7 @@ test('2 keys have local (first with all use pw second with only 1 use pw), 1 has
     *   LOCAL KEY #2 
     */
     await keypom.setKey(keys[1]);
-    await keypom.updateAccessKey(
-        publicKeys[1],  // public key
-        {
-            nonce: 0,
-            permission: 'FullAccess'
-        }
-    )
+
     // Set ali's balance to 0 so we can check if the claim works properly
     await ali.updateAccount({
         amount: "0"
@@ -239,13 +220,7 @@ test('2 keys have local (first with all use pw second with only 1 use pw), 1 has
     *   GLOBAL KEY #1 
     */
     await keypom.setKey(keys[2]);
-    await keypom.updateAccessKey(
-        publicKeys[2],  // public key
-        {
-            nonce: 0,
-            permission: 'FullAccess'
-        }
-    )
+
     // Set ali's balance to 0 so we can check if the claim works properly
     await ali.updateAccount({
         amount: "0"
@@ -311,13 +286,7 @@ test('Add keys after drop is created with passwords', async t => {
     *   LOCAL KEY #1
     */
     await keypom.setKey(keys[0]);
-    await keypom.updateAccessKey(
-        publicKeys[0],  // public key
-        {
-            nonce: 0,
-            permission: 'FullAccess'
-        }
-    )
+
     // Set ali's balance to 0 so we can check if the claim works properly
     await ali.updateAccount({
         amount: "0"
@@ -351,13 +320,7 @@ test('Add keys after drop is created with passwords', async t => {
     *   LOCAL KEY #2 
     */
     await keypom.setKey(keys[1]);
-    await keypom.updateAccessKey(
-        publicKeys[1],  // public key
-        {
-            nonce: 0,
-            permission: 'FullAccess'
-        }
-    )
+
     // Set ali's balance to 0 so we can check if the claim works properly
     await ali.updateAccount({
         amount: "0"
@@ -385,13 +348,7 @@ test('Add keys after drop is created with passwords', async t => {
     *   GLOBAL KEY #1 
     */
     await keypom.setKey(keys[2]);
-    await keypom.updateAccessKey(
-        publicKeys[2],  // public key
-        {
-            nonce: 0,
-            permission: 'FullAccess'
-        }
-    )
+
     // Set ali's balance to 0 so we can check if the claim works properly
     await ali.updateAccount({
         amount: "0"

--- a/__tests__/poaps/poap-tests.ava.ts
+++ b/__tests__/poaps/poap-tests.ava.ts
@@ -89,13 +89,6 @@ test('Fully Claim all Pagoda POAPs', async t => {
 
         for(let i = 0; i < keys.length; i++) {
             await keypom.setKey(keys[i]);
-            await keypom.updateAccessKey(
-                keys[i],  // public key
-                {
-                    nonce: 0,
-                    permission: 'FullAccess'
-                }
-            )
 
             await keypom.call(keypom, 'create_account_and_claim', {new_account_id: `${nonce}-${i}.test.near`, new_public_key : pks2[0]}, {gas: WALLET_GAS});
         }

--- a/__tests__/stage1/test-simple.ava.ts
+++ b/__tests__/stage1/test-simple.ava.ts
@@ -1,6 +1,6 @@
 import anyTest, { TestFn } from "ava";
 import { NEAR, NearAccount, tGas, Worker } from "near-workspaces";
-import { CONTRACT_METADATA, generateKeyPairs, getDropInformation, getKeySupplyForDrop, LARGE_GAS, queryAllViewFunctions, WALLET_GAS } from "../utils/general";
+import { CONTRACT_METADATA, generateKeyPairs, getDropInformation, getKeyInformation, getKeySupplyForDrop, LARGE_GAS, queryAllViewFunctions, WALLET_GAS } from "../utils/general";
 import { DropConfig, SimpleData } from "../utils/types";
 
 const test = anyTest as TestFn<{
@@ -99,8 +99,8 @@ test('Testing Registered Uses Functionalities', async t => {
         amount: "0"
     })
 
-    // THIS SHOULD FAIL SINCE NO KEYS ARE REGISTERED
     await keypom.setKey(keys[0]);
+    //give full access to the key above since failing a transaction would lead to not enough allowance on a regular function call access key
     await keypom.updateAccessKey(
         publicKeys[0],  // public key
         {
@@ -109,7 +109,7 @@ test('Testing Registered Uses Functionalities', async t => {
         }
     )
 
-    // THIS SHOULD FAIL BECAUSE NO PASSWORD PASSED IN
+    // THIS SHOULD FAIL SINCE NO KEYS ARE REGISTERED
     await keypom.call(keypom, 'claim', {account_id: bob.accountId}, {gas: WALLET_GAS});
 
     let bobBal = await bob.availableBalance();
@@ -156,7 +156,6 @@ test('Testing Registered Uses Functionalities', async t => {
     console.log('aliBal: ', aliBal);
     t.is(aliBal, NEAR.parse("1").toString());
 });
-
 
 test('Refunding Partially Registered Simple Drop', async t => {
     const { keypom, ali, bob } = t.context.accounts;
@@ -278,4 +277,62 @@ test('Refunding Critically Registered Simple Drop', async t => {
     let aliBal = await keypom.view('get_user_balance', {account_id: ali.accountId});
     console.log('aliBal: ', aliBal);
     t.is(aliBal, NEAR.parse("15").toString());
+});
+
+test('Attempt to Panic During Claim or CAAC', async t => {
+    const { keypom, ali, bob } = t.context.accounts;
+
+    let keypomBalanceBefore = await keypom.balance();
+    console.log('keypom available INITIAL: ', keypomBalanceBefore.available.toString())
+    console.log('keypom staked INITIAL: ', keypomBalanceBefore.staked.toString())
+    console.log('keypom stateStaked INITIAL: ', keypomBalanceBefore.stateStaked.toString())
+    console.log('keypom total INITIAL: ', keypomBalanceBefore.total.toString())
+
+    await ali.updateAccount({
+        amount: NEAR.parse('10000 N').toString()
+    })
+    
+    let {keys, publicKeys} = await generateKeyPairs(1);
+    await ali.call(keypom, 'add_to_balance', {}, {attachedDeposit: NEAR.parse("1000").toString()});
+
+    let config: DropConfig = {
+        uses_per_key: 1
+    }
+    await ali.call(keypom, 'create_drop', {public_keys: publicKeys, deposit_per_use: NEAR.parse('1').toString(), config},{gas: WALLET_GAS});
+
+    await keypom.setKey(keys[0]);
+    
+    // Query for the access key's allowance
+    let accessKeyInfo = await getKeyInformation(keypom, publicKeys[0]);
+    console.log('accessKeyInfo: ', accessKeyInfo)
+    
+    // Drain contract by calling this 10 times
+    for (let i = 0; i < config.uses_per_key!; i++) {
+        try {
+            await keypom.call(keypom, 'create_account_and_claim', {new_account_id: "foo", new_public_key: "foo"}, {gas: WALLET_GAS});
+        }
+        catch(e) {
+            console.log(e);
+        }
+    }
+
+    let accessKeyInfoAfter = await getKeyInformation(keypom, publicKeys[0]);
+    console.log('accessKeyInfo After: ', accessKeyInfoAfter)
+
+    t.assert(accessKeyInfoAfter.allowance < accessKeyInfo.allowance);
+
+    // Delete the drop and withdraw all balance. Ensure keypom's available balance does not decrease
+    await ali.call(keypom, 'delete_keys', {drop_id: "0"}, {gas: LARGE_GAS});
+
+    let aliBal = await keypom.view('get_user_balance', {account_id: ali.accountId});
+    console.log('aliBal: ', aliBal);
+    await ali.call(keypom, 'withdraw_from_balance', {}, {gas: LARGE_GAS});
+
+    let keypomBalanceAfter = await keypom.balance();
+    console.log('keypom available AFTER: ', keypomBalanceAfter.available.toString())
+    console.log('keypom staked AFTER: ', keypomBalanceAfter.staked.toString())
+    console.log('keypom stateStaked AFTER: ', keypomBalanceAfter.stateStaked.toString())
+    console.log('keypom total AFTER: ', keypomBalanceAfter.total.toString())
+
+    t.assert(NEAR.from(keypomBalanceAfter.available.toString()).gte(NEAR.from(keypomBalanceBefore.available.toString())));
 });

--- a/__tests__/ticketing/ticketing-tests.ava.ts
+++ b/__tests__/ticketing/ticketing-tests.ava.ts
@@ -86,13 +86,6 @@ test('Fully Claim all ticketing keys', async t => {
 
         for(let i = 0; i < keys.length; i++) {
             await keypom.setKey(keys[i]);
-            await keypom.updateAccessKey(
-                keys[i],  // public key
-                {
-                    nonce: 0,
-                    permission: 'FullAccess'
-                }
-            )
 
             await keypom.call(keypom, 'claim', { account_id: bob }, { gas: WALLET_GAS });
             await keypom.call(keypom, 'claim', { account_id: bob }, { gas: WALLET_GAS });
@@ -161,13 +154,6 @@ test('Claim 1 with invalid expected uses', async t => {
 
         for(let i = 0; i < keys.length; i++) {
             await keypom.setKey(keys[i]);
-            await keypom.updateAccessKey(
-                keys[i],  // public key
-                {
-                    nonce: 0,
-                    permission: 'FullAccess'
-                }
-            )
 
             await keypom.call(keypom, 'claim', { account_id: bob, expected_uses: 3 }, { gas: WALLET_GAS });
             await keypom.call(keypom, 'claim', { account_id: bob, expected_uses: 3 }, { gas: WALLET_GAS });


### PR DESCRIPTION
Using the data type `AccountId` or `PublicKey` added unnecessary panics in the expanded contract.

Removed unnecessary conversions of function call access keys to full access keys since workspaces bug has been fixed.