### PR TITLE
Audit Patches

### DIFF
--- a/__tests__/config-tests/config-tests.ava.ts
+++ b/__tests__/config-tests/config-tests.ava.ts
@@ -52,6 +52,9 @@ test.beforeEach(async (t) => {
         amount: NEAR.parse('10000 N').toString()
     })
 
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
+
     // Save state for test runs
     t.context.worker = worker;
     t.context.accounts = { root, keypom, owner, ali, customRoot };

--- a/__tests__/config-tests/config-tests.ava.ts
+++ b/__tests__/config-tests/config-tests.ava.ts
@@ -31,13 +31,7 @@ test.beforeEach(async (t) => {
     //init new keypom contract and setting keypom as the owner. 
     await keypom.call(keypom, 'new', { root_account: 'test.near', owner_id: keypom, contract_metadata: CONTRACT_METADATA });
     
-    //get current keypom (contract) balances 
-    let keypomBalance = await keypom.balance();
-    console.log('keypom available INITIAL: ', keypomBalance.available.toString())
-    console.log('keypom staked INITIAL: ', keypomBalance.staked.toString())
-    console.log('keypom stateStaked INITIAL: ', keypomBalance.stateStaked.toString())
-    console.log('keypom total INITIAL: ', keypomBalance.total.toString())
-
+    
     // Test users, ali.test.near
     const ali = await root.createSubAccount('ali');
     const owner = await root.createSubAccount('owner');
@@ -46,15 +40,22 @@ test.beforeEach(async (t) => {
     const customRoot = await root.createSubAccount('custom-root');
     await customRoot.deploy(`./__tests__/ext-wasm/linkdrop.wasm`);
     await customRoot.call(customRoot, 'new', {});
-
+    
     // Add 10k $NEAR to owner's account
     await owner.updateAccount({
         amount: NEAR.parse('10000 N').toString()
     })
-
+    
     await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
     await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
-
+    
+    //get current keypom (contract) balances 
+    let keypomBalance = await keypom.balance();
+    console.log('keypom available INITIAL: ', keypomBalance.available.toString())
+    console.log('keypom staked INITIAL: ', keypomBalance.staked.toString())
+    console.log('keypom stateStaked INITIAL: ', keypomBalance.stateStaked.toString())
+    console.log('keypom total INITIAL: ', keypomBalance.total.toString())
+    
     // Save state for test runs
     t.context.worker = worker;
     t.context.accounts = { root, keypom, owner, ali, customRoot };

--- a/__tests__/ft-drops/ft-drops.ava.ts
+++ b/__tests__/ft-drops/ft-drops.ava.ts
@@ -47,16 +47,16 @@ test.beforeEach(async (t) => {
     // Mint the FTs
     await ftContract.call(ftContract, 'storage_deposit', { account_id: minter.accountId }, { attachedDeposit: NEAR.parse("1").toString() });
     await ftContract.call(ftContract, 'ft_transfer', { receiver_id: minter.accountId, amount: (oneGtNear * BigInt(1000)).toString() }, { attachedDeposit: "1" });
-
+    
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
+    
     let keypomBalance = await keypom.balance();
     console.log('keypom available INITIAL: ', keypomBalance.available.toString())
     console.log('keypom staked INITIAL: ', keypomBalance.staked.toString())
     console.log('keypom stateStaked INITIAL: ', keypomBalance.stateStaked.toString())
     console.log('keypom total INITIAL: ', keypomBalance.total.toString())
 
-    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
-    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
-    
     // Save state for test runs
     t.context.worker = worker;
     t.context.accounts = { root, keypom, owner, ali, minter, ftContract };

--- a/__tests__/ft-drops/ft-drops.ava.ts
+++ b/__tests__/ft-drops/ft-drops.ava.ts
@@ -54,6 +54,9 @@ test.beforeEach(async (t) => {
     console.log('keypom stateStaked INITIAL: ', keypomBalance.stateStaked.toString())
     console.log('keypom total INITIAL: ', keypomBalance.total.toString())
 
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
+    
     // Save state for test runs
     t.context.worker = worker;
     t.context.accounts = { root, keypom, owner, ali, minter, ftContract };

--- a/__tests__/internals/test-internals.ava.ts
+++ b/__tests__/internals/test-internals.ava.ts
@@ -24,6 +24,9 @@ test.beforeEach(async (t) => {
     const ali = await root.createSubAccount('ali');
     const bob = await root.createSubAccount('bob');
 
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: bob.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
+
     // Save state for test runs
     t.context.worker = worker;
     t.context.accounts = { root, keypom, ali, bob };

--- a/__tests__/nested-fc-fields/nested-fc-fields.ava.ts
+++ b/__tests__/nested-fc-fields/nested-fc-fields.ava.ts
@@ -47,6 +47,10 @@ test.beforeEach(async (t) => {
     const owner = await root.createSubAccount('owner');
     const bob = await root.createSubAccount('bob');
 
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: bob.accountId });
+
     // Save state for test runs
     t.context.worker = worker;
     t.context.accounts = { root, keypom, nftContract, owner, ali, bob };

--- a/__tests__/nested-fc-fields/nested-fc-fields.ava.ts
+++ b/__tests__/nested-fc-fields/nested-fc-fields.ava.ts
@@ -30,6 +30,15 @@ test.beforeEach(async (t) => {
     await keypom.call(keypom, 'new', { root_account: 'test.near', owner_id: keypom, contract_metadata: CONTRACT_METADATA });
     await nftContract.call(nftContract, 'new_default_meta', { owner_id: nftContract });
 
+    // Test users
+    const ali = await root.createSubAccount('ali');
+    const owner = await root.createSubAccount('owner');
+    const bob = await root.createSubAccount('bob');
+    
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: bob.accountId });
+    
     let keypomBalance = await keypom.balance();
     console.log('keypom available INITIAL: ', keypomBalance.available.toString())
     console.log('keypom staked INITIAL: ', keypomBalance.staked.toString())
@@ -41,15 +50,6 @@ test.beforeEach(async (t) => {
     console.log('nftContract staked INITIAL: ', nftBalance.staked.toString())
     console.log('nftContract stateStaked INITIAL: ', nftBalance.stateStaked.toString())
     console.log('nftContract total INITIAL: ', nftBalance.total.toString())
-
-    // Test users
-    const ali = await root.createSubAccount('ali');
-    const owner = await root.createSubAccount('owner');
-    const bob = await root.createSubAccount('bob');
-
-    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
-    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
-    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: bob.accountId });
 
     // Save state for test runs
     t.context.worker = worker;

--- a/__tests__/nft-drops/nft-drops.ava.ts
+++ b/__tests__/nft-drops/nft-drops.ava.ts
@@ -51,6 +51,9 @@ test.beforeEach(async (t) => {
     console.log('keypom stateStaked INITIAL: ', keypomBalance.stateStaked.toString())
     console.log('keypom total INITIAL: ', keypomBalance.total.toString())
 
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
+    
     // Save state for test runs
     t.context.worker = worker;
     t.context.accounts = { root, keypom, owner, ali, minter, nftSeries };

--- a/__tests__/nft-drops/nft-drops.ava.ts
+++ b/__tests__/nft-drops/nft-drops.ava.ts
@@ -44,15 +44,16 @@ test.beforeEach(async (t) => {
     // Mint the NFT
     await nftSeries.call(nftSeries, 'create_series', { mint_id: 0, metadata: nftMetadata }, { attachedDeposit: NEAR.parse("1").toString() });
     await nftSeries.call(nftSeries, 'nft_mint', { mint_id: '0', receiver_id: minter, keypom_args }, { attachedDeposit: NEAR.parse("1").toString() });
-
+    
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
+    
     let keypomBalance = await keypom.balance();
     console.log('keypom available INITIAL: ', keypomBalance.available.toString())
     console.log('keypom staked INITIAL: ', keypomBalance.staked.toString())
     console.log('keypom stateStaked INITIAL: ', keypomBalance.stateStaked.toString())
     console.log('keypom total INITIAL: ', keypomBalance.total.toString())
 
-    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
-    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
     
     // Save state for test runs
     t.context.worker = worker;

--- a/__tests__/passwords/password-tests.ava.ts
+++ b/__tests__/passwords/password-tests.ava.ts
@@ -46,6 +46,10 @@ test.beforeEach(async (t) => {
         amount: NEAR.parse('10000 N').toString()
     })
 
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: bob.accountId });
+
     // Save state for test runs
     t.context.worker = worker;
     t.context.accounts = { root, keypom, owner, ali, bob };

--- a/__tests__/passwords/password-tests.ava.ts
+++ b/__tests__/passwords/password-tests.ava.ts
@@ -30,25 +30,25 @@ test.beforeEach(async (t) => {
     await root.call(root, 'new', {});
     await keypom.call(keypom, 'new', { root_account: 'test.near', owner_id: keypom, contract_metadata: CONTRACT_METADATA });
 
+    // Test users
+    const ali = await root.createSubAccount('ali');
+    const owner = await root.createSubAccount('owner');
+    const bob = await root.createSubAccount('bob');
+    
+    // Add 10k $NEAR to owner's account
+    await owner.updateAccount({
+        amount: NEAR.parse('10000 N').toString()
+    })
+    
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: bob.accountId });
+    
     let keypomBalance = await keypom.balance();
     console.log('keypom available INITIAL: ', keypomBalance.available.toString())
     console.log('keypom staked INITIAL: ', keypomBalance.staked.toString())
     console.log('keypom stateStaked INITIAL: ', keypomBalance.stateStaked.toString())
     console.log('keypom total INITIAL: ', keypomBalance.total.toString())
-
-    // Test users
-    const ali = await root.createSubAccount('ali');
-    const owner = await root.createSubAccount('owner');
-    const bob = await root.createSubAccount('bob');
-
-    // Add 10k $NEAR to owner's account
-    await owner.updateAccount({
-        amount: NEAR.parse('10000 N').toString()
-    })
-
-    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
-    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
-    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: bob.accountId });
 
     // Save state for test runs
     t.context.worker = worker;

--- a/__tests__/poaps/poap-tests.ava.ts
+++ b/__tests__/poaps/poap-tests.ava.ts
@@ -38,6 +38,15 @@ test.beforeEach(async (t) => {
     // Add Keypom as an approved minter
     await nftSeries.call(nftSeries, 'add_approved_minter', { account_id: keypom });
 
+    // Test users
+    const ali = await root.createSubAccount('ali');
+    const owner = await root.createSubAccount('owner');
+    const bob = await root.createSubAccount('bob');
+    
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: bob.accountId });
+
     let keypomBalance = await keypom.balance();
     console.log('keypom available INITIAL: ', keypomBalance.available.toString())
     console.log('keypom staked INITIAL: ', keypomBalance.staked.toString())
@@ -49,15 +58,6 @@ test.beforeEach(async (t) => {
     console.log('nftSeries staked INITIAL: ', nftBalance.staked.toString())
     console.log('nftSeries stateStaked INITIAL: ', nftBalance.stateStaked.toString())
     console.log('nftSeries total INITIAL: ', nftBalance.total.toString())
-
-    // Test users
-    const ali = await root.createSubAccount('ali');
-    const owner = await root.createSubAccount('owner');
-    const bob = await root.createSubAccount('bob');
-
-    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
-    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
-    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: bob.accountId });
 
     // Save state for test runs
     t.context.worker = worker;

--- a/__tests__/poaps/poap-tests.ava.ts
+++ b/__tests__/poaps/poap-tests.ava.ts
@@ -55,6 +55,10 @@ test.beforeEach(async (t) => {
     const owner = await root.createSubAccount('owner');
     const bob = await root.createSubAccount('bob');
 
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: bob.accountId });
+
     // Save state for test runs
     t.context.worker = worker;
     t.context.accounts = { root, keypom, nftSeries, owner, ali, bob };

--- a/__tests__/profiling/profiling.ava.ts
+++ b/__tests__/profiling/profiling.ava.ts
@@ -53,6 +53,8 @@ test.beforeEach(async (t) => {
     await owner.updateAccount({
         amount: NEAR.parse('10000 N').toString()
     })
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
 
     // Save state for test runs
     t.context.worker = worker;

--- a/__tests__/profiling/profiling.ava.ts
+++ b/__tests__/profiling/profiling.ava.ts
@@ -34,12 +34,6 @@ test.beforeEach(async (t) => {
     await root.call(root, 'new', {});
     await keypom.call(keypom, 'new', { root_account: 'test.near', owner_id: keypom, contract_metadata: CONTRACT_METADATA });
     
-    let keypomBalance = await keypom.balance();
-    console.log('keypom available INITIAL: ', keypomBalance.available.toString())
-    console.log('keypom staked INITIAL: ', keypomBalance.staked.toString())
-    console.log('keypom stateStaked INITIAL: ', keypomBalance.stateStaked.toString())
-    console.log('keypom total INITIAL: ', keypomBalance.total.toString())
-
     // Test users
     const ali = await root.createSubAccount('ali');
     const owner = await root.createSubAccount('owner');
@@ -48,13 +42,19 @@ test.beforeEach(async (t) => {
     const customRoot = await root.createSubAccount('custom-root');
     await customRoot.deploy(`./__tests__/ext-wasm/linkdrop.wasm`);
     await customRoot.call(customRoot, 'new', {});
-
+    
     // Add 10k $NEAR to owner's account
     await owner.updateAccount({
         amount: NEAR.parse('10000 N').toString()
     })
     await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
     await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
+    
+    let keypomBalance = await keypom.balance();
+    console.log('keypom available INITIAL: ', keypomBalance.available.toString())
+    console.log('keypom staked INITIAL: ', keypomBalance.staked.toString())
+    console.log('keypom stateStaked INITIAL: ', keypomBalance.stateStaked.toString())
+    console.log('keypom total INITIAL: ', keypomBalance.total.toString())
 
     // Save state for test runs
     t.context.worker = worker;

--- a/__tests__/pub-sales/pub-sales.ava.ts
+++ b/__tests__/pub-sales/pub-sales.ava.ts
@@ -32,27 +32,27 @@ test.beforeEach(async (t) => {
     await root.call(root, 'new', {});
     await keypom.call(keypom, 'new', { root_account: 'test.near', owner_id: keypom, contract_metadata: CONTRACT_METADATA });
 
-    let keypomBalance = await keypom.balance();
-    console.log('keypom available INITIAL: ', keypomBalance.available.toString())
-    console.log('keypom staked INITIAL: ', keypomBalance.staked.toString())
-    console.log('keypom stateStaked INITIAL: ', keypomBalance.stateStaked.toString())
-    console.log('keypom total INITIAL: ', keypomBalance.total.toString())
-
     // Test users
     const ali = await root.createSubAccount('ali');
     const owner = await root.createSubAccount('owner');
     const bob = await root.createSubAccount('bob');
     const eve = await root.createSubAccount('eve');
-
+    
     // Add 10k $NEAR to owner's account
     await owner.updateAccount({
         amount: NEAR.parse('10000 N').toString()
     })
-
+    
     await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
     await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
     await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: bob.accountId });
     await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: eve.accountId });
+    
+    let keypomBalance = await keypom.balance();
+    console.log('keypom available INITIAL: ', keypomBalance.available.toString())
+    console.log('keypom staked INITIAL: ', keypomBalance.staked.toString())
+    console.log('keypom stateStaked INITIAL: ', keypomBalance.stateStaked.toString())
+    console.log('keypom total INITIAL: ', keypomBalance.total.toString())
 
     // Save state for test runs
     t.context.worker = worker;

--- a/__tests__/pub-sales/pub-sales.ava.ts
+++ b/__tests__/pub-sales/pub-sales.ava.ts
@@ -49,6 +49,11 @@ test.beforeEach(async (t) => {
         amount: NEAR.parse('10000 N').toString()
     })
 
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: bob.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: eve.accountId });
+
     // Save state for test runs
     t.context.worker = worker;
     t.context.accounts = { root, keypom, owner, ali, bob, eve };

--- a/__tests__/stage1/test-simple.ava.ts
+++ b/__tests__/stage1/test-simple.ava.ts
@@ -25,6 +25,9 @@ const test = anyTest as TestFn<{
     const ali = await root.createSubAccount('ali');
     const bob = await root.createSubAccount('bob');
 
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: bob.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
+
     // Save state for test runs
     t.context.worker = worker;
     t.context.accounts = { root, keypom, ali, bob };

--- a/__tests__/ticketing/ticketing-tests.ava.ts
+++ b/__tests__/ticketing/ticketing-tests.ava.ts
@@ -37,7 +37,16 @@ test.beforeEach(async (t) => {
     
     // Add Keypom as an approved minter
     await nftSeries.call(nftSeries, 'add_approved_minter', { account_id: keypom });
-
+    
+    // Test users
+    const ali = await root.createSubAccount('ali');
+    const owner = await root.createSubAccount('owner');
+    const bob = await root.createSubAccount('bob');
+    
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: bob.accountId });
+    
     let keypomBalance = await keypom.balance();
     console.log('keypom available INITIAL: ', keypomBalance.available.toString())
     console.log('keypom staked INITIAL: ', keypomBalance.staked.toString())
@@ -49,15 +58,6 @@ test.beforeEach(async (t) => {
     console.log('nftSeries staked INITIAL: ', nftBalance.staked.toString())
     console.log('nftSeries stateStaked INITIAL: ', nftBalance.stateStaked.toString())
     console.log('nftSeries total INITIAL: ', nftBalance.total.toString())
-
-    // Test users
-    const ali = await root.createSubAccount('ali');
-    const owner = await root.createSubAccount('owner');
-    const bob = await root.createSubAccount('bob');
-
-    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
-    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
-    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: bob.accountId });
 
     // Save state for test runs
     t.context.worker = worker;

--- a/__tests__/ticketing/ticketing-tests.ava.ts
+++ b/__tests__/ticketing/ticketing-tests.ava.ts
@@ -55,6 +55,10 @@ test.beforeEach(async (t) => {
     const owner = await root.createSubAccount('owner');
     const bob = await root.createSubAccount('bob');
 
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: bob.accountId });
+
     // Save state for test runs
     t.context.worker = worker;
     t.context.accounts = { root, keypom, nftSeries, owner, ali, bob };

--- a/__tests__/user-args/user-arg-tests.ava.ts
+++ b/__tests__/user-args/user-arg-tests.ava.ts
@@ -47,6 +47,10 @@ test.beforeEach(async (t) => {
     const owner = await root.createSubAccount('owner');
     const bob = await root.createSubAccount('bob');
 
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: bob.accountId });
+
     // Save state for test runs
     t.context.worker = worker;
     t.context.accounts = { root, keypom, nftContract, owner, ali, bob };

--- a/__tests__/user-args/user-arg-tests.ava.ts
+++ b/__tests__/user-args/user-arg-tests.ava.ts
@@ -30,6 +30,15 @@ test.beforeEach(async (t) => {
     await keypom.call(keypom, 'new', { root_account: 'test.near', owner_id: keypom, contract_metadata: CONTRACT_METADATA });
     await nftContract.call(nftContract, 'new_default_meta', { owner_id: nftContract });
 
+    // Test users
+    const ali = await root.createSubAccount('ali');
+    const owner = await root.createSubAccount('owner');
+    const bob = await root.createSubAccount('bob');
+    
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
+    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: bob.accountId });
+    
     let keypomBalance = await keypom.balance();
     console.log('keypom available INITIAL: ', keypomBalance.available.toString())
     console.log('keypom staked INITIAL: ', keypomBalance.staked.toString())
@@ -41,15 +50,6 @@ test.beforeEach(async (t) => {
     console.log('nftContract staked INITIAL: ', nftBalance.staked.toString())
     console.log('nftContract stateStaked INITIAL: ', nftBalance.stateStaked.toString())
     console.log('nftContract total INITIAL: ', nftBalance.total.toString())
-
-    // Test users
-    const ali = await root.createSubAccount('ali');
-    const owner = await root.createSubAccount('owner');
-    const bob = await root.createSubAccount('bob');
-
-    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: owner.accountId });
-    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: ali.accountId });
-    await keypom.call(keypom, 'add_to_refund_allowlist', { account_id: bob.accountId });
 
     // Save state for test runs
     t.context.worker = worker;

--- a/contract/src/internals/owner.rs
+++ b/contract/src/internals/owner.rs
@@ -21,6 +21,18 @@ impl Keypom {
         self.contract_metadata.replace(&contract_metadata);
     }
 
+    /// Add an account ID to the list of accounts that can receive refunds for unspent key allowance.
+    pub fn add_to_refund_allowlist(&mut self, account_id: AccountId) {
+        self.assert_owner();
+        self.refund_allowlist.insert(&account_id);
+    }
+    
+    /// Add an account ID to the list of accounts that can receive refunds for unspent key allowance.
+    pub fn remove_from_refund_allowlist(&mut self, account_id: AccountId) {
+        self.assert_owner();
+        self.refund_allowlist.remove(&account_id);
+    }
+
     /// Add a prohibited method to the list of methods that can't be called by a FC Drop
     pub fn add_prohibited_method(&mut self, method: String) {
         self.assert_owner();
@@ -55,6 +67,18 @@ impl Keypom {
     pub fn set_gas_price(&mut self, yocto_per_gas: u128) {
         self.assert_owner();
         self.yocto_per_gas = yocto_per_gas;
+    }
+
+    /// Set the contract to be frozen thus not allowing any drops to be created or keys added
+    pub fn freeze_contract(&mut self) {
+        self.assert_owner();
+        self.global_freeze = true
+    }
+    
+    /// Set the contract to be unfrozen thus resuming the ability for drops and keys to be created
+    pub fn unfreeze_contract(&mut self) {
+        self.assert_owner();
+        self.global_freeze = false;
     }
 
     /// Withdraw the fees collected to the passed in Account Id

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -966,6 +966,7 @@ enum StorageKey {
     UserBalances,
     ProhibitedMethods,
     RegisteredFtContracts,
+    RefundAllowlist,
     ContractMetadata,
 }
 
@@ -992,7 +993,6 @@ pub struct Keypom {
     pub key_fee: u128,
     /// Total amount of fees available for withdrawal collected overtime.
     pub fees_collected: u128,
-
     /// Overload the `drop_fee` and `key_fee` for specific users by providing custom fees
     /// Tuple is (drop_fee, key_fee)
     pub fees_per_user: LookupMap<AccountId, (u128, u128)>,
@@ -1011,6 +1011,12 @@ pub struct Keypom {
 
     /// Which contract has Keypom been automatically registered on?
     pub registered_ft_contracts: LookupSet<AccountId>,
+
+    /// Which accounts will be automatically refunded for any unused gas.
+    pub refund_allowlist: LookupSet<AccountId>,
+    
+    /// Whether or not the contract is frozen and no new drops can be created / keys added.
+    pub global_freeze: bool,
 
     /// Source metadata extension:
     pub contract_metadata: LazyOption<ContractSourceMetadata>,
@@ -1035,6 +1041,8 @@ impl Keypom {
             next_drop_id: 0,
             prohibited_fc_methods: LookupSet::new(StorageKey::ProhibitedMethods),
             registered_ft_contracts: LookupSet::new(StorageKey::RegisteredFtContracts),
+            refund_allowlist: LookupSet::new(StorageKey::RefundAllowlist),
+            global_freeze: false,
             /*
                 FEES
             */

--- a/contract/src/stage1/drops.rs
+++ b/contract/src/stage1/drops.rs
@@ -42,6 +42,8 @@ impl Keypom {
         // Pessimistically measure storage
         let initial_storage = env::storage_usage();
 
+        require!(self.global_freeze == false, "Contract is frozen and no new drops or keys can be created");
+
         let mut actual_drop_id = self.next_drop_id;
 
         if let Some(id) = drop_id {
@@ -588,6 +590,8 @@ impl Keypom {
         passwords_per_use: Option<Vec<Option<Vec<JsonPasswordForUse>>>>,
         passwords_per_key: Option<Vec<Option<String>>>,
     ) -> Option<DropIdJson> {
+        require!(self.global_freeze == false, "Contract is frozen and no new drops or keys can be created");
+        
         let mut drop = self
             .drop_for_id
             .get(&drop_id.0)

--- a/contract/src/stage1/sale.rs
+++ b/contract/src/stage1/sale.rs
@@ -197,11 +197,11 @@ impl Keypom {
         let (current_user_balance, _) = self.attached_deposit_to_user_balance(&owner_id);
 
         if let Some(mut sale) = config.sale {
-            sale.max_num_keys = max_num_keys;
-            sale.price_per_key = price_per_key.map(|p| p.0);
-            sale.auto_withdraw_funds = auto_withdraw_funds;
-            sale.start = start;
-            sale.end = end;
+            sale.max_num_keys = if max_num_keys.is_some() { max_num_keys } else { sale.max_num_keys };
+            sale.price_per_key = if price_per_key.is_some() { price_per_key.map(|p| p.0) } else { sale.price_per_key };
+            sale.auto_withdraw_funds = if auto_withdraw_funds.is_some() { auto_withdraw_funds } else { sale.auto_withdraw_funds };
+            sale.start = if start.is_some() { start } else { sale.start };
+            sale.end = if end.is_some() { end } else { sale.end };
 
             config.sale = Some(sale);
             drop.config = Some(config);


### PR DESCRIPTION
- add_to_refund_allowlist / remove_from_refund_allowlist
- freeze_contract / unfreeze_contract
- Owner can now delete keys and refund assets
- Only refund if in allowlist
- Fixed bug in `update_sale` that would overwrite variables even if they weren't passed in.